### PR TITLE
pitchExtract: xcorr syntax requires argument order (x,y,maxlag,scaleT…

### DIFF
--- a/soundanalysis/pitchExtract.m
+++ b/soundanalysis/pitchExtract.m
@@ -336,7 +336,7 @@ corrs = zeros(maxlag*2+1,length(windowStarts));
 j=1;
 for i = windowStarts
     windowsignal = a(i:(i+ws-1)).*tukeywin(ws,0.7);
-    [corrs(:,j),~] = xcorr(windowsignal,windowsignal,'coeff',maxlag);    
+    [corrs(:,j),~] = xcorr(windowsignal,windowsignal,maxlag,'coeff');    
     
     %tmp solution for calculating rms:
     rmss(j)=rms(smooth(windowsignal,5));


### PR DESCRIPTION
pitchExtract: xcorr syntax requires argument order (x,y,maxlag,scaleType)

cf xcorr.m parseinput l. 289